### PR TITLE
Keep URL params from command line

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -83,7 +83,7 @@ public class Program
         {
             try
             {
-                startUrl = args.FirstOrDefault(x => x.StartsWith("--url")).Split("=")[1];
+                startUrl = String.Join("=", args.FirstOrDefault(x => x.StartsWith("--url")).Split("=")[1..]);
             }
             catch (Exception)
             {


### PR DESCRIPTION
When using a command line like `--data=http://example.com?data=value`, keep everything after the first `=` as-is.  Without this, the startURL would end up being `http://example.com?data`